### PR TITLE
add correct meta data

### DIFF
--- a/extension.properties
+++ b/extension.properties
@@ -1,5 +1,5 @@
 name=@extname@
-description=The extension description can be customized by editing the extension.properties file.
-author=
+description=loader for the STM32F2 series of microcontrollers
+author=wrongbaud
 createdOn=
 version=@extversion@


### PR DESCRIPTION
Currently metadata about the extension is displayed wrongly (default placeholder).

Fixed to display correct metadata.