### PR TITLE
Removed DuplicateNameException

### DIFF
--- a/src/main/java/stm32/stm32Loader.java
+++ b/src/main/java/stm32/stm32Loader.java
@@ -441,8 +441,7 @@ public class stm32Loader extends AbstractLibrarySupportLoader {
 		}
 		try {
 			mem.createInitializedBlock("Main Memory", api.toAddr(0x8000000), inStream, 0xFFFFF, monitor, false);
-		} catch (LockException | MemoryConflictException | AddressOverflowException | CancelledException
-				| DuplicateNameException e) {
+		} catch (LockException | MemoryConflictException | AddressOverflowException | CancelledException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}


### PR DESCRIPTION
Ran into `error: exception DuplicateNameException is never thrown in body of corresponding try statement` on the following system:

```
------------------------------------------------------------
Gradle 4.4.1
------------------------------------------------------------

Build time:   2012-12-21 00:00:00 UTC
Revision:     none

Groovy:       2.4.16
Ant:          Apache Ant(TM) version 1.10.5 compiled on August 27 2018
JVM:          11.0.9.1 (Debian 11.0.9.1+1-post-Debian-1deb10u2)
```

Removing the `DuplicateNameException` from the catch allows the extension to compile successfully.

Full error output:

```
$ gradle -PGHIDRA_INSTALL_DIR=/opt/ghidra_9.2.1_PUBLIC
Starting a Gradle Daemon (subsequent builds will be faster)

> Task :compileJava FAILED
/ghidra-stm32/src/main/java/stm32/stm32Loader.java:444: error: exception DuplicateNameException is never thrown in body of corresponding try statement
                } catch (LockException | MemoryConflictException | AddressOverflowException | CancelledException
                  ^
1 error


FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileJava'.
> Compilation failed; see the compiler error output for details.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 13s
1 actionable task: 1 executed
```